### PR TITLE
fix: handle radio changes and single file upload

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,13 +15,15 @@ const App = () => {
 
   const { showModal, toggle } = useModal();
 
-  const setTheme = () => setIsDarkTheme(state => !state);
+  const setTheme = () => setIsDarkTheme(state => !state)
 
   useEffect(() => {
     if (!image) return
+
+
     const imageUrl = URL.createObjectURL(image[0])
     setImageURL(imageUrl)
-  }, image)
+  }, [image])
 
 
   const handleSubmit = (e) => {

--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -11,6 +11,8 @@ import "./Form.css"
 
 export const Form = ({ handleSubmit, setImage, setNetwork }) => {
 
+    const handleRadioChange = (e) => setNetwork(e.target.value)
+
     return (
         <FormControl className="form">
             <ImageUploader
@@ -21,13 +23,14 @@ export const Form = ({ handleSubmit, setImage, setNetwork }) => {
                 buttonClassName="upload-button"
                 onChange={setImage}
                 imgExtension={[".jpg", ".png"]}
+                singleImage={true}
                 maxFileSize={5242880} />
             Select a network:
             <RadioGroup
                 aria-labelledby="network-label"
                 defaultValue="alexnet"
                 name="network"
-                onChange={setNetwork}
+                onChange={handleRadioChange}
                 className="radio-group"
             >
                 <FormControlLabel value="alexnet" control={<Radio />} label="AlexNet" />


### PR DESCRIPTION
Fixes:
- There was a problem with the output when changing radio buttons
- The image uploader was able to take on several files - this was a problem for the file reader and was causing the app to crash

